### PR TITLE
Configure symbol of line comment to use `#@#`

### DIFF
--- a/review.configuration.json
+++ b/review.configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#@#"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This change enable user to toggle `#@#` comment by `Ctrl` or `Command` + `/`.

Reference: https://github.com/kmuto/review/blob/master/doc/format.md#comments