### PR TITLE
Stop auto indentation after entering new line

### DIFF
--- a/review.configuration.json
+++ b/review.configuration.json
@@ -3,12 +3,6 @@
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         "lineComment": "#@#"
     },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
         ["{", "}"],


### PR DESCRIPTION
## Problem

Currently, indentation is automatically inserted when entering new line after `{` character. As Re:VIEW language does not use indentation for control structure, this behavior is useless.

## Changes

This PR removes `brackets` property from configuration. The change stops auto indentation behavior.

## Before

![before](https://user-images.githubusercontent.com/532251/41819330-9a834f14-77f9-11e8-8834-dd3c26933426.gif)

## After

![after](https://user-images.githubusercontent.com/532251/41819332-a080273e-77f9-11e8-8d10-dda96e188fc5.gif)

## Reference

https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributeslanguages

> `brackets` - Defines the bracket symbols that influence the indentation of code between the brackets. Used by the editor to determine or correct the new indentation level when entering a new line.