### PR TITLE
Support nested (hierarchical) outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "Apache License Version 2.0",
     "publisher": "atsushieno",
     "engines": {
-        "vscode": "^1.1.2"
+        "vscode": "^1.25.0"
     },
     "repository": {
       "type": "git",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -27,7 +27,7 @@ class ReviewTextDocumentContentProvider implements vscode.TextDocumentContentPro
 		});
 	}
 
-	public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.SymbolInformation[] | Thenable<vscode.SymbolInformation[]> {
+	public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.SymbolInformation[] | Thenable<vscode.DocumentSymbol[]> {
 		return processDocument (document).then (book => document_symbols);
 	}
 
@@ -91,7 +91,13 @@ function showPreview (uri: vscode.Uri) {
 	return vscode.commands.executeCommand ('vscode.previewHtml', getSpecialSchemeUri (uri), vscode.ViewColumn.Two);
 }
 
-var document_symbols: vscode.SymbolInformation[] = Array.of<vscode.SymbolInformation> ();
+var document_symbols: vscode.DocumentSymbol[] = Array.of<vscode.DocumentSymbol> ();
+
+interface ReviewSymbol {
+	readonly level: number;
+	readonly parent: ReviewSymbol | undefined;
+	readonly children: vscode.DocumentSymbol[]
+}
 
 function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 	return review.start (controller => {
@@ -110,16 +116,55 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 			listener: {
 				// onAcceptables: ... ,
 				onSymbols: function (symbols) {
-					document_symbols = symbols.map<vscode.SymbolInformation> ((src, idx, arr) => {
+					function organizeSymbols (parent: ReviewSymbol, symbols: review.Symbol[]) {
+						if (!symbols.length) {
+							return;
+						}
+
+						let symbol = symbols[0];
+						let docSymbol = new vscode.DocumentSymbol (
+							getLabelName (symbol), "", vscode.SymbolKind.Null, locationToRange (symbol.node.location), locationToRange (symbol.node.location));
+						let level = extractLevel (symbol);
+						if (docSymbol === undefined || level === -Infinity) {
+							return;
+						}
+						docSymbol.children = [];
+						while (parent && level <= parent.level) {
+							parent = parent.parent!;
+						}
+						parent.children.push (docSymbol);
+						organizeSymbols ({level, children: docSymbol.children, parent}, symbols.slice (1));
+					}
+
+					function extractLevel (src: review.Symbol): number {
 						switch (src.symbolName) {
 							case "hd":
-								return new vscode.SymbolInformation (src.labelName, vscode.SymbolKind.Null, locationToRange (src.node.location), document.uri, "Re:View Index");
+								return src.node.toHeadline ().level;
 							case "column":
-								return new vscode.SymbolInformation ("[column] " + src.node.toColumn().headline.caption.childNodes[0].toTextNode().text, vscode.SymbolKind.Null, locationToRange (src.node.location), document.uri, "Re:View Index");
+								return src.node.toColumn ().level;
+							default:
+								return -Infinity;
+						}
+					}
+
+					function getLabelName (src: review.Symbol): string {
+						switch (src.symbolName) {
+							case "hd":
+								return src.labelName;
+							case "column":
+								return "[column] " + src.node.toColumn ().headline.caption.childNodes[0].toTextNode ().text;
 							default:
 								return undefined;
 						}
-					}).filter(ret => ret !== undefined);
+					}
+
+					const root: ReviewSymbol = {
+						level: -Infinity,
+						children: [],
+						parent: undefined
+					};
+					organizeSymbols (root, symbols.filter (o => o.symbolName === "hd" || o.symbolName === "column"));
+					document_symbols = root.children;
 				},
 				onReports: function (reports) {
 					var dc = Array.of<vscode.Diagnostic> ();


### PR DESCRIPTION
vscode 1.25.0 supports nested outline (mentioned on release-notes [here](https://code.visualstudio.com/updates/v1_25#_hierarchical-markdown-document-symbols)). This PR is an integration of the feature against language-review.

Most implementation was done regarding the change-set applied for markdown extension:
https://github.com/Microsoft/vscode/commit/33446a0a9e66efbfc106ffa08b948b63d77afdc2#diff-6f61f45e93144bb28b0b411f726ded3f

![image](https://user-images.githubusercontent.com/766864/42363779-c053a610-8133-11e8-9477-7c2bea025f5d.png)
