### PR TITLE
Support breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "Apache License Version 2.0",
     "publisher": "atsushieno",
     "engines": {
-        "vscode": "^1.1.2"
+        "vscode": "^1.25.0"
     },
     "repository": {
       "type": "git",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     },
     "devDependencies": {
       "typescript": "^2.0.3",
-      "vscode": "^1.1.2",
+      "vscode": "^1.1.18",
       "mocha": "^2.3.3",
       "@types/node": "^8.0.0",
       "@types/mocha": "^2.2.32"

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -164,7 +164,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 						children: [],
 						parent: undefined
 					};
-					organizeSymbols (root, symbols.filter (o => !o.node.isInlineElement() && o.symbolName === "hd" || o.symbolName === "column"));
+					organizeSymbols (root, symbols.filter (o => !o.node.isInlineElement() && (o.symbolName === "hd" || o.symbolName === "column")));
 					document_symbols = root.children;
 				},
 				onReports: function (reports) {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -138,10 +138,10 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 					}
 
 					function extractLevel (src: review.Symbol): number {
-						switch (src.symbolName) {
-							case "hd":
+						switch (src.node.ruleName) {
+							case review.RuleName.Headline:
 								return src.node.toHeadline ().level;
-							case "column":
+							case review.RuleName.Column:
 								return src.node.toColumn ().level;
 							default:
 								return -Infinity;
@@ -149,10 +149,10 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 					}
 
 					function getLabelName (src: review.Symbol): string {
-						switch (src.symbolName) {
-							case "hd":
+						switch (src.node.ruleName) {
+							case review.RuleName.Headline:
 								return src.labelName;
-							case "column":
+							case review.RuleName.Column:
 								return "[column] " + src.node.toColumn ().headline.caption.childNodes[0].toTextNode ().text;
 							default:
 								return undefined;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -164,7 +164,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 						children: [],
 						parent: undefined
 					};
-					organizeSymbols (root, symbols.filter (o => o.symbolName === "hd" || o.symbolName === "column"));
+					organizeSymbols (root, symbols.filter (o => !o.node.isInlineElement() && o.symbolName === "hd" || o.symbolName === "column"));
 					document_symbols = root.children;
 				},
 				onReports: function (reports) {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -27,7 +27,7 @@ class ReviewTextDocumentContentProvider implements vscode.TextDocumentContentPro
 		});
 	}
 
-	public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.SymbolInformation[] | Thenable<vscode.SymbolInformation[]> {
+	public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.SymbolInformation[] | Thenable<vscode.DocumentSymbol[]> {
 		return processDocument (document).then (book => document_symbols);
 	}
 
@@ -91,8 +91,14 @@ function showPreview (uri: vscode.Uri) {
 	return vscode.commands.executeCommand ('vscode.previewHtml', getSpecialSchemeUri (uri), vscode.ViewColumn.Two);
 }
 
-var document_symbols: vscode.SymbolInformation[] = Array.of<vscode.SymbolInformation> ();
+var document_symbols: vscode.DocumentSymbol[] = Array.of<vscode.DocumentSymbol> ();
 var last_diagnostics: vscode.DiagnosticCollection = null;
+
+interface ReviewSymbol {
+	readonly level: number;
+	readonly parent: ReviewSymbol | undefined;
+	readonly children: vscode.DocumentSymbol[]
+}
 
 function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 	return review.start (controller => {
@@ -111,16 +117,55 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 			listener: {
 				// onAcceptables: ... ,
 				onSymbols: function (symbols) {
-					document_symbols = symbols.map<vscode.SymbolInformation> ((src, idx, arr) => {
+					function organizeSymbols (parent: ReviewSymbol, symbols: review.Symbol[]) {
+						if (!symbols.length) {
+							return;
+						}
+
+						let symbol = symbols[0];
+						let docSymbol = new vscode.DocumentSymbol (
+							getLabelName (symbol), "", vscode.SymbolKind.Null, locationToRange (symbol.node.location), locationToRange (symbol.node.location));
+						let level = extractLevel (symbol);
+						if (docSymbol === undefined || level === -Infinity) {
+							return;
+						}
+						docSymbol.children = [];
+						while (parent && level <= parent.level) {
+							parent = parent.parent!;
+						}
+						parent.children.push (docSymbol);
+						organizeSymbols ({level, children: docSymbol.children, parent}, symbols.slice (1));
+					}
+
+					function extractLevel (src: review.Symbol): number {
 						switch (src.symbolName) {
 							case "hd":
-								return new vscode.SymbolInformation (src.labelName, vscode.SymbolKind.Null, locationToRange (src.node.location), document.uri, "Re:View Index");
+								return src.node.toHeadline ().level;
 							case "column":
-								return new vscode.SymbolInformation ("[column] " + src.node.toColumn().headline.caption.childNodes[0].toTextNode().text, vscode.SymbolKind.Null, locationToRange (src.node.location), document.uri, "Re:View Index");
+								return src.node.toColumn ().level;
+							default:
+								return -Infinity;
+						}
+					}
+
+					function getLabelName (src: review.Symbol): string {
+						switch (src.symbolName) {
+							case "hd":
+								return src.labelName;
+							case "column":
+								return "[column] " + src.node.toColumn ().headline.caption.childNodes[0].toTextNode ().text;
 							default:
 								return undefined;
 						}
-					}).filter(ret => ret !== undefined);
+					}
+
+					const root: ReviewSymbol = {
+						level: -Infinity,
+						children: [],
+						parent: undefined
+					};
+					organizeSymbols (root, symbols.filter (o => o.symbolName === "hd" || o.symbolName === "column"));
+					document_symbols = root.children;
 				},
 				onReports: function (reports) {
 					var dc = Array.of<vscode.Diagnostic> ();


### PR DESCRIPTION
Depends on #16 

Actual diff: https://github.com/muojp/vscode-language-review/compare/fix-outline-regression...muojp:support-breadcrumbs?expand=1

With this PR, vscode-language-review supports Breadcrumbs feature introduced in VS Code 1.26.
https://code.visualstudio.com/updates/v1_26#_breadcrumbs

### Notes for the reviewers

 - We need to provide **correct** document structure (ranges) to vscode for proper breadcrumbs navigation.
 - Due to the back-end (review.js) doesn't feed us chapter structure, current implementation is a bit hacky and complicated.