### PR TITLE
Refactor a bit to improve CSS flexibility.

### DIFF
--- a/media/style.css
+++ b/media/style.css
@@ -1,0 +1,4 @@
+body {
+    color: black;
+    background-color: white;
+}


### PR DESCRIPTION
In considering https://github.com/vvakame/review.js/pull/38 , I noticed it would be nice to have a bit of flexibility for CSS using Webview API introduced in a0a6a10ef0493a6ba2f8d21d63d0124554466aa6 .

Also, maybe one day we will be able to adopt VSCode's theming feature on top of this pull-req: https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content 