### PR TITLE
Add caption for chapters which have label in outline view

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -163,7 +163,8 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 					function getLabelName (src: review.Symbol): string {
 						switch (src.node.ruleName) {
 							case review.RuleName.Headline:
-								return src.labelName;
+								const caption = src.node.toHeadline().caption.childNodes[0].toTextNode().text;
+								return caption === src.labelName ? src.labelName : `{${src.labelName}} ${caption}`;
 							case review.RuleName.Column:
 								return "[column] " + src.node.toColumn ().headline.caption.childNodes[0].toTextNode ().text;
 							default:


### PR DESCRIPTION
It is not so user friendly that outline window just show chapters' label instead of their caption when they have explicitly specified label like `=={label} CAPTION`.

This PR enables display chapters' captions in outline view of vscode even if they also have labels.