### PR TITLE
Enables cross chapter @<hd>{...} (and others)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
   },
   "dependencies": {
     "rx-lite": "4.0.8",
-    "review.js": "0.16.0"
+    "review.js-vscode": "0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "rx-lite": "4.0.8",
-    "review.js-vscode": "0.18.0"
+    "review.js-vscode": "0.18.0",
+    "js-yaml": "^3.13.0"
   }
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -5,7 +5,7 @@ import * as events from 'events';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as rx from 'rx-lite';
-import * as review from 'review.js';
+import * as review from 'review.js-vscode';
 import { clearTimeout } from 'timers';
 
 const review_scheme = "review";


### PR DESCRIPTION
This PR adds cross chapter `@<hd>{...}` support.

To do so, this PR includes following fixes:
* Change reference to `review.js` to my forked version, because it was crashed when it reads cross chapter  `@<hd>{...}`.
  * The new package also fixes a number of bugs and adds some features. See [release page](https://github.com/yfakariya/review.js-vscode/releases/tag/v0.18.0) for details.
* Support analysis of other files which are listed in `catalog.yml`. It is required to resolve cross chapter symbols.