### PR TITLE
Fix inline element in caption crashes the extension

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,13 +1,10 @@
 'use strict';
 
 import * as fs from 'fs';
-import * as events from 'events';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as rx from 'rx-lite';
 import * as review from 'review.js-vscode';
 import * as jsyaml from "js-yaml";
-import { clearTimeout } from 'timers';
 import { ConfigBook } from 'review.js-vscode/lib/controller/configRaw';
 
 const review_scheme = "review";
@@ -233,7 +230,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 								p = p.parent;
 							}
 						}
-					}
+					} // organizeSymbols()
 
 					function extractLevel (src: review.Symbol): number {
 						switch (src.node.ruleName) {
@@ -256,7 +253,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 							default:
 								return undefined;
 						}
-					}
+					} // getLabelName()
 
 					function getLabelDetail (src: review.Symbol): string {
 						switch (src.node.ruleName) {


### PR DESCRIPTION
This PR adds support of inline node such as `@<b>{...}`, so fixes two problems:

* If the caption starts with inline, the extension crashes.
* If the caption contains any inlines but it starts with text, only the head text part is shown.