### PR TITLE
Outline label for columns

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -292,8 +292,8 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 							case review.RuleName.Column: {
 								const column = src.node.toColumn ();
 								const caption = getCaptionText (column.headline.caption);
-								const label = column.headline.label.arg;
-								return caption === label ? caption : `{${label}} ${caption}`;
+								const label = column.headline.label?.arg;
+								return (label == null || caption === label) ? caption : `{${label}} ${caption}`;
 							}
 							default:
 								return undefined;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -293,7 +293,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 								const column = src.node.toColumn ();
 								const caption = getCaptionText (column.headline.caption);
 								const label = column.headline.label?.arg;
-								return (label == null || caption === label) ? caption : `{${label}} ${caption}`;
+								return (label == null || caption === label) ? `[column] ${caption}` : `[column] {${label}} ${caption}`;
 							}
 							default:
 								return undefined;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -285,11 +285,16 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 						} // getCaptionText()
 
 						switch (src.node.ruleName) {
-							case review.RuleName.Headline:
+							case review.RuleName.Headline: {
 								const caption = getCaptionText (src.node.toHeadline ().caption);
 								return caption === src.labelName ? src.labelName : `{${src.labelName}} ${caption}`;
-							case review.RuleName.Column:
-								return "[column] " + getCaptionText (src.node.toColumn ().headline.caption);
+							}
+							case review.RuleName.Column: {
+								const column = src.node.toColumn ();
+								const caption = getCaptionText (column.headline.caption);
+								const label = column.headline.label.arg;
+								return caption === label ? caption : `{${label}} ${caption}`;
+							}
 							default:
 								return undefined;
 						}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,13 +1,10 @@
 'use strict';
 
 import * as fs from 'fs';
-import * as events from 'events';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as rx from 'rx-lite';
 import * as review from 'review.js-vscode';
 import * as jsyaml from "js-yaml";
-import { clearTimeout } from 'timers';
 import { ConfigBook } from 'review.js-vscode/lib/controller/configRaw';
 
 const review_scheme = "review";
@@ -233,7 +230,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 								p = p.parent;
 							}
 						}
-					}
+					} // organizeSymbols()
 
 					function extractLevel (src: review.Symbol): number {
 						switch (src.node.ruleName) {
@@ -256,7 +253,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 							default:
 								return undefined;
 						}
-					}
+					} // getLabelName()
 
 					function getLabelDetail (src: review.Symbol): string {
 						switch (src.node.ruleName) {


### PR DESCRIPTION
This PR is supplement of #28, and uses new function which was added in #30.

I knew that I could retrieve labels of columns after #28, so I implemented label support for columns in addition to headlines(chapters).