### PR TITLE
Add draft mode, custom css, and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,19 @@
           "group": "navigation"
         }
       ]
-    }
+    },
+    "configuration":[
+      {
+        "title": "Re:VIEW",
+        "properties": {
+          "languageReview.preview.draftMode": {
+            "markdownDescription": "Enable 'draft' mode which shows contents of inline comment (`@<comment>{...}`) and block comment (`//comment{...//}`).",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "rx-lite": "4.0.8",
-    "review.js-vscode": "0.18.0",
+    "review.js-vscode": "0.19.1",
     "js-yaml": "^3.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         }
       ]
     },
-    "configuration":[
+    "configuration": [
       {
         "title": "Re:VIEW",
         "properties": {
@@ -84,8 +84,8 @@
             "type": "boolean",
             "default": false
           },
-          "languageReview.preview.stylesheet": {
-            "description": "File name or path of css file to be applied to preview window.",
+          "languageReview.experimentalFeatures.preview.stylesheet": {
+            "description": "[Advanced option]\nFile name or path of css file to be applied to preview window.\nNote that this is 'alpha' feature, so subject to change in future release.",
             "type": "string",
             "default": "stylesheet.css"
           }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
             "markdownDescription": "Enable 'draft' mode which shows contents of inline comment (`@<comment>{...}`) and block comment (`//comment{...//}`).",
             "type": "boolean",
             "default": false
+          },
+          "languageReview.preview.stylesheet": {
+            "description": "File name or path of css file to be applied to preview window.",
+            "type": "string",
+            "default": "stylesheet.css"
           }
         }
       }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -30,6 +30,20 @@ class ReviewSymbolProvider implements vscode.DocumentSymbolProvider, vscode.Disp
 	}
 }
 
+interface Configuration {
+	readonly draftMode: boolean;
+}
+
+function getConfiguration () : Configuration {
+	// Specify first segment of properties which is defined in package.json/contributes/configuration
+	const vsconfig = vscode.workspace.getConfiguration ("languageReview");
+
+	// Specify remaining segments of properties here:
+	return {
+		draftMode: vsconfig.get<boolean> ("preview.draftMode") ?? false,
+	}
+}
+
 function convert_review_doc_to_html (document: vscode.TextDocument, getAssetUri: (...relPath: string[]) => vscode.Uri): Promise<string> {
 	const docFileName = path.basename(document.fileName);
 
@@ -140,7 +154,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 	}
 
 	const options = {
-		draft: false,
+		draft: getConfiguration().draftMode,
 		inproc: true
 	};
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -139,6 +139,11 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 		};
 	}
 
+	const options = {
+		draft: false,
+		inproc: true
+	};
+
 	return review.start (controller => {
 		var prhFile = path.join (path.dirname (document.fileName), "prh.yml");
 		var validators: review.Validator[];
@@ -146,7 +151,6 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 
 		const docFileName = path.basename (document.fileName);
 		const docDirName = path.dirname (document.fileName);
-		const docChapterName = path.basename (document.fileName, ".re");
 
 		const catalogYamlFileName = path.resolve (docDirName, "catalog.yml");
 		const books =
@@ -353,7 +357,7 @@ function processDocument (document: vscode.TextDocument): Promise<review.Book> {
 			builders: [ new review.HtmlBuilder (false) ],
 			book: books
 		});
-	});
+	}, options);
 }
 
 var previews = new Map<string,vscode.WebviewPanel> ();


### PR DESCRIPTION
This PR upgrades `preview.js-vscode` to 0.19.1 and add some features related it.

* With 0.19.1, we can
  * Use `//table` block with inline elements
  * Use fence notation for inline elements like `@<tt>|void main(){}|`
  * Use `@<chap>{}`, `@<chapref>{}`, and `@<title>{}`
  * Escaping of closing braces support on inline elements like `@<tt>{void main(){\}}`
  * Inproc mode and draft mode describing bellow
  * But we lose nested inline elements support, because `preview.js-vscode` now prohibit it to improve compatibility with Ruby implementation and [the spec](https://github.com/kmuto/review/blob/master/doc/format.md) never allowed nesting.
* New feature of the extension
  * Optional draft mode support, which shows inline and block comment for editorial purposes. The name is borrowed from [the option of Ruby implementation](https://github.com/kmuto/review/blob/master/doc/format.md#comments)
  * Implicitly using inproc mode of the review.js-vscode which prevents verbose log causes by `process.exit()` call of the compiler.
  * Custom CSS specification.
