### PR TITLE
Fix generic block command pattern to support optional caption arguments

### DIFF
--- a/syntaxes/review.tmLanguage
+++ b/syntaxes/review.tmLanguage
@@ -753,7 +753,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^(//)([^\{\[\]]+)(\{)</string>
+			<string>^(//)([^\{\[\]]+)(\[((\\]|[^]])*)\])?(\{)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -766,14 +766,19 @@
 					<key>name</key>
 					<string>support.function.review</string>
 				</dict>
-				<key>3</key>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>string.review</string>
+				</dict>
+				<key>6</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.review</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>//hoge{ ... //}</string>
+			<string>//hoge[caption]{ ... //} or //hoge{ ... //}</string>
 			<key>end</key>
 			<string>(^//\})</string>
 			<key>endCaptures</key>


### PR DESCRIPTION
## Problem

Block commands that take an optional caption argument — such as `//note[caption]{`, `//warning[caption]{`, `//caution[caption]{`, `//tip[caption]{` — were not matched by the generic block pattern:

```
^(//)([^\{\[\]]+)(\{)
```

The character class `[^\{\[\]]+` explicitly excludes square brackets `[` and `]`, so any command followed by `[...]` would fail to match. This caused VS Code to show syntax errors on valid Re:VIEW markup.

## Fix

Updated the generic block pattern to allow an optional `[caption]` argument:

```
^(//)([^\{\[\]]+)(\[((\\]|[^]])*)\])?(\{)
```

- The command name part `([^\{\[\]]+)` is unchanged — no square brackets in the name itself
- Added `(\[((\\]|[^]])*)\])?` to match an optional caption in square brackets (supports escaped `\]` inside)
- Updated `beginCaptures` accordingly: group 4 captures the caption text as `string.review`, group 6 captures `{` as `keyword.review`

This approach is consistent with how `//emlist` is already handled:

```
^(//)(emlist)(\[((\\]|[^]])*)\])?(\{)
```

## Examples that now work correctly

```
//note[This is a note caption]{
content
//}

//warning[Caution]{
content
//}

//note{
content without caption also still works
//}
```